### PR TITLE
Improve playground layout

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -88,37 +88,51 @@ function App() {
     <div className={`app theme-${theme}`}>
       <header className="header">
         <span className="title">POLSIA</span>
-        <button className="switcher" onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
+        <button
+          className="switcher"
+          onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+        >
           Switch to {theme === 'dark' ? 'light' : 'dark'}
         </button>
       </header>
-      <div className="editor">
-        <label className="power">
-          power level:
-          <select value={power} onChange={(e) => setPower(e.target.value as any)}>
-            <option value="low">low (emacs)</option>
-            <option value="medium">medium (basic)</option>
-            <option value="high">high (vim)</option>
-          </select>
-        </label>
-        <CodeMirror
-          className="pane"
-          theme={theme}
-          height="100%"
-          value={src}
-          extensions={extensions}
-          onChange={(v) => {
-            setSrc(v)
-            update(v)
-          }}
-        />
-        <pre className="pane">{output}</pre>
+      <div className="content">
+        <div className="editor">
+          <div className="section-header">
+            <span>Polsia Input</span>
+            <label className="power">
+              power level:
+              <select
+                value={power}
+                onChange={(e) => setPower(e.target.value as any)}
+              >
+                <option value="low">low (emacs)</option>
+                <option value="medium">medium (basic)</option>
+                <option value="high">high (vim)</option>
+              </select>
+            </label>
+          </div>
+          <CodeMirror
+            className="pane"
+            theme={theme}
+            height="100%"
+            value={src}
+            extensions={extensions}
+            onChange={(v) => {
+              setSrc(v)
+              update(v)
+            }}
+          />
+          <div ref={statusRef} id="status" className="status"></div>
+        </div>
+        <div className="output">
+          <div className="section-header">
+            <span>JSON Output</span>
+          </div>
+          <pre className="pane">{output}</pre>
+        </div>
       </div>
-      <div ref={statusRef} id="status" className="status"></div>
       <footer className="footer">
-        <Marquee autoFill>
-          POLSIA &nbsp;
-        </Marquee>
+        <Marquee autoFill>POLSIA &nbsp;</Marquee>
       </footer>
     </div>
   )

--- a/playground/src/index.css
+++ b/playground/src/index.css
@@ -41,29 +41,43 @@ body, html, #root {
 }
 
 
-.editor {
+
+.content {
   flex: 1;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
+.editor,
+.output {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px;
+  border-bottom: 1px solid currentColor;
+}
+
 .pane {
   flex: 1;
-  height: 50%;
+  height: 100%;
   box-sizing: border-box;
 }
 
 @media (min-width: 700px) {
-  .editor {
+  .content {
     flex-direction: row;
-  }
-  .pane {
-    height: 100%;
   }
 }
 
-.editor pre {
+.output pre {
   margin: 0;
   padding: 10px;
   overflow: auto;


### PR DESCRIPTION
## Summary
- arrange the playground using explicit flex containers
- add headers for the Polsia input and JSON output panes

## Testing
- `cargo fmt -- --check`
- `cargo test`
- `cargo clippy`
- `cargo check --target wasm32-unknown-unknown --features wasm`
- `wasm-pack build --target bundler --release -- --features wasm`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68439a23e694832caa5615303f062078