### PR TITLE
Setup ESLint and Prettier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,5 +11,6 @@
 - After installing dependencies:
    - run `wasm-pack build --target bundler --release -- --features wasm`
    - run `npm test` in `playground/` to verify the frontend
+   - run `npm run lint` and `npm run format` in `playground/` when changing frontend code
    - run `npm run build` in `playground/` to ensure the React playground compiles.
 

--- a/playground/.prettierignore
+++ b/playground/.prettierignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -24,9 +24,12 @@
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
         "eslint": "^9.25.0",
+        "eslint-config-prettier": "^10.1.5",
+        "eslint-plugin-prettier": "^5.4.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
+        "prettier": "^3.5.3",
         "typescript": "^5.4.0",
         "vite": "^6.3.5",
         "vite-plugin-top-level-await": "^1.5.0",
@@ -1202,6 +1205,19 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
+      "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
     },
     "node_modules/@replit/codemirror-emacs": {
       "version": "6.1.0",
@@ -2524,6 +2540,53 @@
         }
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.1.tgz",
+      "integrity": "sha512-9dF+KuU/Ilkq27A8idRP7N2DH8iUR6qXcjF3FR2wETY21PZdBrIjwCau8oboyGj9b7etWmTGEeM8e7oOed6ZWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
@@ -2681,6 +2744,13 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3417,6 +3487,35 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -3706,6 +3805,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
+      "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.4"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
       }
     },
     "node_modules/tinybench": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "test": "npm run typecheck && vitest run",
     "typecheck": "tsc --noEmit",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "format": "prettier . --check"
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.4",
@@ -28,9 +29,12 @@
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
     "eslint": "^9.25.0",
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-prettier": "^5.4.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "prettier": "^3.5.3",
     "typescript": "^5.4.0",
     "vite": "^6.3.5",
     "vite-plugin-top-level-await": "^1.5.0",

--- a/playground/prettier.config.cjs
+++ b/playground/prettier.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  semi: false,
+  singleQuote: true,
+  trailingComma: 'es5',
+}

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -6,7 +6,7 @@ import { emacs } from '@replit/codemirror-emacs'
 import type { Extension } from '@codemirror/state'
 import Marquee from 'react-fast-marquee'
 import './index.css'
-import * as wasm  from 'polsia'
+import * as wasm from 'polsia'
 
 const DEFAULT_SRC = `# Polsia (Edit me!)
 # https://github.com/contagnas/polsia
@@ -54,7 +54,7 @@ users: dmed: {
 
 trailingCommas: true,
 
-# }`;
+# }`
 
 function App() {
   const [theme, setTheme] = useState<'dark' | 'light'>('dark')
@@ -64,7 +64,7 @@ function App() {
   const statusRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
-    (async () => {
+    ;(async () => {
       setOutput(wasm.polsia_to_json(src))
     })()
   }, [])
@@ -79,7 +79,9 @@ function App() {
 
   const extensions: Extension[] = [javascript()]
   if (power === 'high') {
-    extensions.unshift(vim({ status: true, statusbar: statusRef.current } as any))
+    extensions.unshift(
+      vim({ status: true, statusbar: statusRef.current } as any)
+    )
   } else if (power === 'low') {
     extensions.unshift(emacs())
   }

--- a/playground/src/index.css
+++ b/playground/src/index.css
@@ -1,4 +1,6 @@
-body, html, #root {
+body,
+html,
+#root {
   margin: 0;
   padding: 0;
   height: 100%;
@@ -9,7 +11,7 @@ body, html, #root {
   display: flex;
   flex-direction: column;
   height: 100%;
-  font-family: "Courier New", monospace;
+  font-family: 'Courier New', monospace;
   box-sizing: border-box;
   overflow: hidden;
 }
@@ -27,7 +29,6 @@ body, html, #root {
   margin-right: 1rem;
 }
 
-
 .power {
   margin: 4px;
 }
@@ -39,8 +40,6 @@ body, html, #root {
   background: inherit;
   color: inherit;
 }
-
-
 
 .content {
   flex: 1;
@@ -97,12 +96,12 @@ body, html, #root {
 
 .theme-dark {
   background: black;
-  color: #00FF00;
+  color: #00ff00;
 }
 
 .theme-light {
-  background: #FFFFE0;
-  color: #FF00FF;
+  background: #ffffe0;
+  color: #ff00ff;
 }
 
 .switcher {

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -6,5 +6,5 @@ import App from './App'
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
+  </StrictMode>
 )

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,14 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import wasm from "vite-plugin-wasm"
-import topLevelAwait from "vite-plugin-top-level-await"
+import wasm from 'vite-plugin-wasm'
+import topLevelAwait from 'vite-plugin-top-level-await'
 
 // https://vite.dev/config/
 export default defineConfig({
   base: '/polsia/',
-  plugins: [
-    react(),
-    wasm(),
-    topLevelAwait()
-  ],
+  plugins: [react(), wasm(), topLevelAwait()],
 })


### PR DESCRIPTION
## Summary
- add Prettier with basic config and ignore file
- format existing playground sources with Prettier
- expose a `format` npm script
- remind Codex to run `npm run lint` and `npm run format` in `playground/`

## Testing
- `cargo fmt -- --check` *(fails: 'cargo-fmt' is not installed)*
- `cargo test`
- `cargo clippy` *(fails: 'cargo-clippy' is not installed)*
- `cargo check --target wasm32-unknown-unknown --features wasm`
- `wasm-pack build --target bundler --release -- --features wasm`
- `npm test`
- `npm run build`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6843a1216de4832c99ad1cb49279d098