### PR TITLE
Move playground demo to shared file and add parser test

### DIFF
--- a/examples/demo.pls
+++ b/examples/demo.pls
@@ -1,0 +1,47 @@
+# Polsia (Edit me!)
+# https://github.com/contagnas/polsia
+#
+# Polsia is a data/configuration language, similar to CUE, and a superset of JSON
+
+### Syntax sugar features ###
+# Comments start with #
+# this is a comment
+
+# braces may be skipped in a top-level object
+# {
+
+"hello": "world",
+
+# quotes are optional for object keys
+goodbye: "moon",
+
+# commas are optional in objects
+commas: "optional"
+
+# braces are optional for objects with a single key
+foo: bar: baz: "nested"
+
+### Unification ###
+# keys may be duplicated, as long as they don't conflict
+simple_string: "string"
+simple_string: "string"
+
+# Polsia has types. Types are values which unify with values of that type.
+# Built-in types: Any, Nothing, Int, Number, Rational, Float, String
+funny_number: Int
+funny_number: 69
+
+# Object keys are merged together
+users: forest: age: 4
+users: forest: species: "bear"
+users: meadow: age: 4
+users: meadow: species: "cat"
+users: dmed: {
+  age: Int
+  age: 1e100
+  species: "Doctor"
+}
+
+trailingCommas: true,
+
+# }

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -8,54 +8,9 @@ import type { Extension } from '@codemirror/state'
 import Marquee from 'react-fast-marquee'
 import './index.css'
 import * as wasm from 'polsia'
+import demoSrc from '../../examples/demo.pls?raw'
 
-const DEFAULT_SRC = `# Polsia (Edit me!)
-# https://github.com/contagnas/polsia
-#
-# Polsia is a data/configuration language, similar to CUE, and a superset of JSON
-
-### Syntax sugar features ###
-# Comments start with #
-# this is a comment
-
-# braces may be skipped in a top-level object
-# {
-
-"hello": "world",
-
-# quotes are optional for object keys
-goodbye: "moon",
-
-# commas are optional in objects
-commas: "optional"
-
-# braces are optional for objects with a single key
-foo: bar: baz: "nested"
-
-### Unification ###
-# keys may be duplicated, as long as they don't conflict
-simple_string: "string"
-simple_string: "string"
-
-# Polsia has types. Types are values which unify with values of that type.
-# Built-in types: Any, Nothing, Int, Number, Rational, Float, String
-funny_number: Int
-funny_number: 69
-
-# Object keys are merged together
-users: forest: age: 4
-users: forest: species: "bear"
-users: meadow: age: 4
-users: meadow: species: "cat"
-users: dmed: {
-  age: Int
-  age: 1e100
-  species: "Doctor"
-}
-
-trailingCommas: true,
-
-# }`
+const DEFAULT_SRC = demoSrc
 
 function App() {
   const [theme, setTheme] = useState<'dark' | 'light'>('dark')

--- a/playground/src/pls.d.ts
+++ b/playground/src/pls.d.ts
@@ -1,0 +1,4 @@
+declare module '*.pls?raw' {
+  const src: string
+  export default src
+}

--- a/playground/tests/demo-import.test.ts
+++ b/playground/tests/demo-import.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest'
+import demoSrc from '../../examples/demo.pls?raw'
+
+test('demo source file loads', () => {
+  expect(typeof demoSrc).toBe('string')
+  expect(demoSrc.length).toBeGreaterThan(0)
+})

--- a/polsia/src/lib.rs
+++ b/polsia/src/lib.rs
@@ -427,4 +427,13 @@ mod tests {
         let unified = unify_tree(&parsed).unwrap();
         assert_eq!(unified.to_value().to_pretty_string(), "1");
     }
+
+    #[test]
+    fn demo_file_parses_to_json() {
+        let src = std::fs::read_to_string("../examples/demo.pls").unwrap();
+        let parsed = parser().parse(&src).into_result().unwrap();
+        let unified = unify_tree(&parsed).unwrap();
+        let json = unified.to_value().to_pretty_string();
+        assert!(!json.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
- refactor playground to load demo source from `examples/demo.pls`
- declare a module for `*.pls?raw` imports
- test the demo source can be parsed and converted to JSON
- added vitest test to check demo file import

## Testing
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_6843f828e6a8832cbfb4fd8b84df76a3