### PR TITLE
Switch to YAML syntax highlighting

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -8,9 +8,8 @@
       "name": "playground",
       "version": "0.0.0",
       "dependencies": {
-        "@codemirror/lang-javascript": "^6.2.4",
         "@codemirror/lang-json": "^6.0.1",
-        "@codemirror/lang-python": "^6.2.1",
+        "@codemirror/lang-yaml": "^6.1.2",
         "@replit/codemirror-emacs": "^6.1.0",
         "@replit/codemirror-vim": "^6.3.0",
         "@uiw/react-codemirror": "^4.23.12",
@@ -372,21 +371,6 @@
         "@lezer/common": "^1.1.0"
       }
     },
-    "node_modules/@codemirror/lang-javascript": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
-      "integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.6.0",
-        "@codemirror/lint": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.17.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/javascript": "^1.0.0"
-      }
-    },
     "node_modules/@codemirror/lang-json": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.1.tgz",
@@ -397,17 +381,19 @@
         "@lezer/json": "^1.0.0"
       }
     },
-    "node_modules/@codemirror/lang-python": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
-      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.2.tgz",
+      "integrity": "sha512-dxrfG8w5Ce/QbT7YID7mWZFKhdhsaTNOYjOkSIMt1qmC4VQnXSDSYVHHHn8k6kJUfIhtLo8t1JJgltlxWdsITw==",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/autocomplete": "^6.3.2",
-        "@codemirror/language": "^6.8.0",
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.2.1",
-        "@lezer/python": "^1.1.4"
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
       }
     },
     "node_modules/@codemirror/language": {
@@ -1205,17 +1191,6 @@
         "@lezer/common": "^1.0.0"
       }
     },
-    "node_modules/@lezer/javascript": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.1.tgz",
-      "integrity": "sha512-ATOImjeVJuvgm3JQ/bpo2Tmv55HSScE2MTPnKRMRIPx2cLhHGyX2VnqpHhtIV1tVzIjZDbcWQm+NCTF40ggZVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.1.3",
-        "@lezer/lr": "^1.3.0"
-      }
-    },
     "node_modules/@lezer/json": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
@@ -1236,15 +1211,15 @@
         "@lezer/common": "^1.0.0"
       }
     },
-    "node_modules/@lezer/python": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.18.tgz",
-      "integrity": "sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==",
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.3.tgz",
+      "integrity": "sha512-GuBLekbw9jDBDhGur82nuwkxKQ+a3W5H0GfaAthDXcAu+XdpS43VlnxA9E9hllkpSP5ellRDKjLLj7Lu9Wr6xA==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
+        "@lezer/lr": "^1.4.0"
       }
     },
     "node_modules/@marijn/find-cluster-break": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@codemirror/lang-python": "^6.2.1",
+    "@codemirror/lang-yaml": "^6.1.2",
     "@replit/codemirror-emacs": "^6.1.0",
     "@replit/codemirror-vim": "^6.3.0",
     "@uiw/react-codemirror": "^4.23.12",

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import CodeMirror from '@uiw/react-codemirror'
-import { pythonLanguage } from '@codemirror/lang-python'
+import { yaml } from '@codemirror/lang-yaml'
 import { json } from '@codemirror/lang-json'
 import { vim } from '@replit/codemirror-vim'
 import { emacs } from '@replit/codemirror-emacs'
@@ -32,7 +32,7 @@ function App() {
     }
   }
 
-  const extensions: Extension[] = [pythonLanguage]
+  const extensions: Extension[] = [yaml()]
   if (power === 'high') {
     extensions.unshift(
       vim({ status: true } as any)

--- a/polsia/src/lib.rs
+++ b/polsia/src/lib.rs
@@ -434,8 +434,9 @@ mod tests {
     #[test]
     fn demo_file_parses_to_json() {
         let src = std::fs::read_to_string("../examples/demo.pls").unwrap();
-        let parsed = parser().parse(&src).into_result().unwrap();
-        let unified = unify_tree(&parsed).unwrap();
+        let doc = document().parse(&src).into_result().unwrap();
+        let mut unified = unify_tree(&doc.value).unwrap();
+        apply_directives_spanned(&mut unified, &doc.directives);
         let json = unified.to_value().to_pretty_string();
         assert!(!json.is_empty());
     }


### PR DESCRIPTION
## Summary
- use `@codemirror/lang-yaml` in the playground editor
- update playground dependencies
- fix `demo_file_parses_to_json` test to apply directives

## Testing
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_6844d55ff9a8832cbab54401d6bb8285