### PR TITLE
Add Boolean built-in type

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Polsia is a small experimental data language parser written in Rust using the [c
 - unquoted identifiers as keys
 - optional commas and braces for single objects
 - chained keys like `foo: bar: 1` for nested objects
-- basic type annotations (`Int`, `Float`, `String`, `Any`, `Nothing`)
+- basic type annotations (`Int`, `Float`, `String`, `Boolean`, `Any`, `Nothing`)
 
 ## Examples
 

--- a/examples/demo.pls
+++ b/examples/demo.pls
@@ -28,7 +28,7 @@ simple_string: "string"
 simple_string: "string"
 
 # Polsia has types. Types are values which unify with values of that type.
-# Built-in types: Any, Nothing, Int, Number, Rational, Float, String
+# Built-in types: Any, Nothing, Int, Number, Rational, Float, String, Boolean
 funny_number: Int
 funny_number: 69
 

--- a/polsia/src/parser.rs
+++ b/polsia/src/parser.rs
@@ -70,6 +70,7 @@ pub fn document<'a>() -> impl Parser<'a, &'a str, Document, extra::Err<Rich<'a, 
                     | "Rational"
                     | "Float"
                     | "String"
+                    | "Boolean"
             )
         });
 
@@ -282,6 +283,7 @@ fn spanned_value_no_pad<'a>() -> impl Parser<'a, &'a str, SpannedValue, extra::E
                         | "Rational"
                         | "Float"
                         | "String"
+                        | "Boolean"
                 )
             })
             .map_with(|s: String, e| SpannedValue {
@@ -329,6 +331,10 @@ fn spanned_value_no_pad<'a>() -> impl Parser<'a, &'a str, SpannedValue, extra::E
             just("String").map_with(|_, e| SpannedValue {
                 span: e.span(),
                 kind: ValueKind::Type(ValType::String),
+            }),
+            just("Boolean").map_with(|_, e| SpannedValue {
+                span: e.span(),
+                kind: ValueKind::Type(ValType::Boolean),
             }),
             number,
             string,

--- a/polsia/src/types.rs
+++ b/polsia/src/types.rs
@@ -99,6 +99,7 @@ pub enum ValType {
     Rational,
     Float,
     String,
+    Boolean,
 }
 
 fn remove_path(value: &mut Value, parts: &[&str]) {

--- a/polsia/src/unify.rs
+++ b/polsia/src/unify.rs
@@ -18,6 +18,7 @@ fn type_name(t: &ValType) -> &'static str {
         ValType::Rational => "Rational",
         ValType::Float => "Float",
         ValType::String => "String",
+        ValType::Boolean => "Boolean",
     }
 }
 
@@ -79,6 +80,11 @@ fn unify_type_value(t: &ValType, val: &Value) -> Result<Value, String> {
             Value::String(s) => Ok(Value::String(s.clone())),
             Value::Type(other) => unify_types(t, other).map(Value::Type),
             _ => Err("expected string".into()),
+        },
+        ValType::Boolean => match val {
+            Value::Bool(b) => Ok(Value::Bool(*b)),
+            Value::Type(other) => unify_types(t, other).map(Value::Type),
+            _ => Err("expected boolean".into()),
         },
     }
 }


### PR DESCRIPTION
## Summary
- introduce `Boolean` built-in type
- update parser and unifier for the new type
- document the new type in README and demo

## Testing
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_6845bb542600832c97ea182b4310c155