### PR TITLE
Implement sum types

### DIFF
--- a/polsia/src/parser.rs
+++ b/polsia/src/parser.rs
@@ -291,7 +291,7 @@ fn spanned_value_no_pad<'a>() -> impl Parser<'a, &'a str, SpannedValue, extra::E
                 kind: ValueKind::Reference(s),
             });
 
-        choice((
+        let atom = choice((
             just("null").map_with(|_, e| SpannedValue {
                 span: e.span(),
                 kind: ValueKind::Null,
@@ -342,6 +342,18 @@ fn spanned_value_no_pad<'a>() -> impl Parser<'a, &'a str, SpannedValue, extra::E
             object,
             chain,
             reference,
-        ))
+        ));
+
+        let union = atom
+            .clone()
+            .separated_by(just('|').padded_by(ws))
+            .at_least(2)
+            .collect()
+            .map_with(|vals, e| SpannedValue {
+                span: e.span(),
+                kind: ValueKind::Union(vals),
+            });
+
+        choice((union, atom))
     })
 }

--- a/polsia/src/types.rs
+++ b/polsia/src/types.rs
@@ -14,6 +14,7 @@ pub enum Value {
     Object(Vec<(String, Value)>),
     Reference(String),
     Type(ValType),
+    Union(Vec<Value>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -44,6 +45,7 @@ pub enum ValueKind {
     Object(Vec<(String, SpannedValue, Span)>),
     Reference(String),
     Type(ValType),
+    Union(Vec<SpannedValue>),
 }
 
 impl SpannedValue {
@@ -62,6 +64,7 @@ impl SpannedValue {
             ),
             ValueKind::Reference(r) => Value::Reference(r.clone()),
             ValueKind::Type(t) => Value::Type(t.clone()),
+            ValueKind::Union(items) => Value::Union(items.iter().map(|v| v.to_value()).collect()),
         }
     }
 }
@@ -82,6 +85,7 @@ impl Value {
             }
             Value::Reference(r) => JsValue::String(r.clone()),
             Value::Type(t) => panic!("unresolved type {:?}", t),
+            Value::Union(_) => panic!("unresolved union"),
         }
     }
 


### PR DESCRIPTION
## Summary
- add a `Union` variant for values
- parse `|` to form a union
- support union unification logic
- expose unresolved unions in error checks
- test sum type behaviour
- add object sum type tests
- prevent unions matching object branches without required keys
- fix noexport with sum types

## Testing
- `just test`
- `just polsia test`


------
https://chatgpt.com/codex/tasks/task_e_684607c2edc8832c81bba44bce43c910