### PR TITLE
Add custom Polsia codemirror extension

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@codemirror/lang-yaml": "^6.1.2",
         "@replit/codemirror-emacs": "^6.1.0",
         "@replit/codemirror-vim": "^6.3.0",
         "@uiw/react-codemirror": "^4.23.12",
@@ -379,21 +378,6 @@
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@lezer/json": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-yaml": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.2.tgz",
-      "integrity": "sha512-dxrfG8w5Ce/QbT7YID7mWZFKhdhsaTNOYjOkSIMt1qmC4VQnXSDSYVHHHn8k6kJUfIhtLo8t1JJgltlxWdsITw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.2.0",
-        "@lezer/lr": "^1.0.0",
-        "@lezer/yaml": "^1.0.0"
       }
     },
     "node_modules/@codemirror/language": {
@@ -1209,17 +1193,6 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/yaml": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.3.tgz",
-      "integrity": "sha512-GuBLekbw9jDBDhGur82nuwkxKQ+a3W5H0GfaAthDXcAu+XdpS43VlnxA9E9hllkpSP5ellRDKjLLj7Lu9Wr6xA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.4.0"
       }
     },
     "node_modules/@marijn/find-cluster-break": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@codemirror/lang-yaml": "^6.1.2",
     "@replit/codemirror-emacs": "^6.1.0",
     "@replit/codemirror-vim": "^6.3.0",
     "@uiw/react-codemirror": "^4.23.12",

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import CodeMirror from '@uiw/react-codemirror'
-import { yaml } from '@codemirror/lang-yaml'
+import { polsia } from './polsia'
 import { json } from '@codemirror/lang-json'
 import { vim } from '@replit/codemirror-vim'
 import { emacs } from '@replit/codemirror-emacs'
@@ -36,7 +36,7 @@ function App() {
     }
   }
 
-  const extensions: Extension[] = [yaml()]
+  const extensions: Extension[] = [polsia()]
   if (power === 'high') {
     extensions.unshift(
       vim({ status: true } as any)

--- a/playground/src/polsia.ts
+++ b/playground/src/polsia.ts
@@ -1,0 +1,91 @@
+import { StreamLanguage } from '@codemirror/language'
+import type { StreamParser, StringStream } from '@codemirror/language'
+
+interface State {
+  inString: boolean
+  escape: boolean
+  indent: number
+}
+
+const parser: StreamParser<State> = {
+  startState() {
+    return { inString: false, escape: false, indent: 0 }
+  },
+
+  token(stream: StringStream, state: State) {
+    if (state.inString) {
+      while (!stream.eol()) {
+        const ch = stream.next()
+        if (state.escape) {
+          state.escape = false
+          continue
+        }
+        if (ch === '\\') {
+          state.escape = true
+        } else if (ch === '"') {
+          state.inString = false
+          break
+        }
+      }
+      return 'string'
+    }
+
+    if (stream.match(/^#.*/)) return 'comment'
+
+    if (stream.match('"')) {
+      state.inString = true
+      return 'string'
+    }
+
+    if (
+      stream.match(
+        /\b(?:noexport|null|true|false|Any|Nothing|Int|Number|Rational|Float|String|Boolean)\b/
+      )
+    ) {
+      return 'keyword'
+    }
+
+    if (stream.match(/-?(?:0|[1-9][\d]*)(?:\.\d+)?(?:[eE][+-]?\d+)?/)) {
+      return 'number'
+    }
+
+    if (!state.inString && stream.match('{')) {
+      state.indent++
+      return 'bracket'
+    }
+
+    if (!state.inString && stream.match('}')) {
+      state.indent = Math.max(0, state.indent - 1)
+      return 'bracket'
+    }
+
+    if (!state.inString && stream.match('[')) {
+      state.indent++
+      return 'bracket'
+    }
+
+    if (!state.inString && stream.match(']')) {
+      state.indent = Math.max(0, state.indent - 1)
+      return 'bracket'
+    }
+
+    if (stream.match(/[{},\[\]]/)) return 'bracket'
+
+    if (stream.match(/:/)) return 'operator'
+
+    if (stream.match(/[A-Za-z_][\w.]*/)) return 'variableName'
+
+    stream.next()
+    return null
+  },
+
+  indent(state: State, textAfter: string) {
+    let level = state.indent
+    if (/^[\}\]]/.test(textAfter)) level--
+    return Math.max(0, level) * 2
+  },
+}
+
+export function polsia() {
+  return StreamLanguage.define(parser)
+}


### PR DESCRIPTION
## Summary
- add basic stream-parser for Polsia syntax highlighting
- use the custom language extension in the playground
- clean up package dependencies
- indent text inside braces or brackets

## Testing
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_68463f74c3cc832caf076b35f95ffb44