### PR TITLE
Fix union/type mismatch detection

### DIFF
--- a/polsia/src/lib.rs
+++ b/polsia/src/lib.rs
@@ -605,6 +605,25 @@ stringOrInt: false
     }
 
     #[test]
+    fn sum_type_string_or_int_float_type_fails() {
+        let src = r#"
+StringOrInt: String | Int
+StringOrInt: Float
+StringOrInt: 3.4
+"#;
+        must_err(src);
+    }
+
+    #[test]
+    fn sum_type_string_or_int_float_type_no_value_fails() {
+        let src = r#"
+StringOrInt: String | Int
+StringOrInt: Float
+"#;
+        must_err(src);
+    }
+
+    #[test]
     fn sum_type_nested_bool() {
         let src = r#"
 stringOrInt: String | Int

--- a/polsia/src/unify.rs
+++ b/polsia/src/unify.rs
@@ -26,6 +26,7 @@ fn branch_matches(
         (Some(ValueKind::Object(bm)), Some(ValueKind::Object(vm))) => vm
             .iter()
             .all(|(vk, _, _)| bm.iter().any(|(k, _, _)| k == vk)),
+        (Some(ValueKind::Type(bt)), Some(ValueKind::Type(vt))) => bt == vt,
         _ => true,
     }
 }
@@ -600,6 +601,9 @@ pub fn unify_with_path(a: &Value, b: &Value, path: &str) -> Result<Value, String
         (Value::Union(opts), _other) => {
             let mut results = Vec::new();
             for o in opts {
+                if matches!((o, b), (Value::Type(bt), Value::Type(vt)) if bt != vt) {
+                    continue;
+                }
                 if let Ok(res) = unify_with_path(o, b, path) {
                     results.push(res);
                 }
@@ -615,6 +619,9 @@ pub fn unify_with_path(a: &Value, b: &Value, path: &str) -> Result<Value, String
         (_other, Value::Union(opts)) => {
             let mut results = Vec::new();
             for o in opts {
+                if matches!((a, o), (Value::Type(vt), Value::Type(bt)) if bt != vt) {
+                    continue;
+                }
                 if let Ok(res) = unify_with_path(a, o, path) {
                     results.push(res);
                 }


### PR DESCRIPTION
## Summary
- ensure union branches only match identical types
- fail to unify when union branch types differ
- add regression tests for union/type mismatch

## Testing
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_6848aca101f8832c9f4c87840da6a9bc