### PR TITLE
Refactor annotation handling

### DIFF
--- a/polsia/src/main.rs
+++ b/polsia/src/main.rs
@@ -1,7 +1,7 @@
 use ariadne::{Color, Label, Report, ReportKind, sources};
 use chumsky::prelude::*;
 use polsia::types::Span;
-use polsia::{SpannedValue, ValueKind, apply_annotations_spanned, document, unify_tree};
+use polsia::{SpannedValue, ValueKind, document, unify_tree};
 use std::{env, fs};
 
 fn find_unresolved(value: &SpannedValue) -> Option<(Span, String)> {
@@ -25,7 +25,7 @@ fn find_unresolved(value: &SpannedValue) -> Option<(Span, String)> {
             None
         }
         ValueKind::Object(members) => {
-            for (_, v, _) in members {
+            for (_, v, _, _) in members {
                 if let Some(res) = find_unresolved(v) {
                     return Some(res);
                 }
@@ -42,8 +42,7 @@ fn main() {
     let parse_result = document().parse(&src).into_result();
     match parse_result {
         Ok(doc) => match unify_tree(&doc.value) {
-            Ok(mut value) => {
-                apply_annotations_spanned(&mut value, &doc.annotations);
+            Ok(value) => {
                 if let Some((span, t)) = find_unresolved(&value) {
                     let msg = format!("value of type {} is unspecified", t);
                     let span_range = span.into_range();

--- a/polsia/src/wasm.rs
+++ b/polsia/src/wasm.rs
@@ -1,4 +1,4 @@
-use crate::{apply_annotations_spanned, document, unify_tree};
+use crate::{document, unify_tree};
 use ariadne::{Color, Config, Label, Report, ReportKind, sources};
 use chumsky::prelude::*;
 use wasm_bindgen::prelude::*;
@@ -26,7 +26,7 @@ fn find_unresolved(value: &SpannedValue) -> Option<(Span, String)> {
             None
         }
         ValueKind::Object(members) => {
-            for (_, v, _) in members {
+            for (_, v, _, _) in members {
                 if let Some(res) = find_unresolved(v) {
                     return Some(res);
                 }
@@ -43,8 +43,7 @@ pub fn polsia_to_json(src: &str) -> Result<String, String> {
     let parse_result = document().parse(src).into_result();
     match parse_result {
         Ok(doc) => match unify_tree(&doc.value) {
-            Ok(mut value) => {
-                apply_annotations_spanned(&mut value, &doc.annotations);
+            Ok(value) => {
                 if let Some((span, t)) = find_unresolved(&value) {
                     let msg = format!("value of type {} is unspecified", t);
                     let span_range = span.into_range();


### PR DESCRIPTION
## Summary
- simplify `Annotation` and `Document`
- store annotations inside object members
- update parser to attach annotations while parsing
- adjust unification and export logic for new annotation storage
- drop old annotation extraction logic

## Testing
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_684a6f9ab6f8832ca3c71abae9adfff2