### PR TITLE
Add native function call support

### DIFF
--- a/polsia/src/lib.rs
+++ b/polsia/src/lib.rs
@@ -1134,4 +1134,25 @@ foo: increment two
             _ => panic!("expected object"),
         }
     }
+
+    #[test]
+    fn call_increment_nested_reference() {
+        let src = r#"
+my: favorite: number: 2
+foo: increment my.favorite.number
+"#;
+        let unified = must_unify(src);
+        match &unified.kind {
+            ValueKind::Object(members) => {
+                let foo = members
+                    .iter()
+                    .find(|(k, _, _, _)| k == "foo")
+                    .unwrap()
+                    .1
+                    .clone();
+                assert_eq!(foo.to_value(), Value::Int(3));
+            }
+            _ => panic!("expected object"),
+        }
+    }
 }

--- a/polsia/src/parser.rs
+++ b/polsia/src/parser.rs
@@ -296,6 +296,25 @@ fn spanned_value_no_pad<'a>()
                 )
             });
 
+        let hspace = one_of(" \t").repeated().at_least(1).ignored();
+
+        let call = reference.then_ignore(hspace).then(value.clone()).map_with(
+            |((func, _), (arg, _)), e| {
+                let name = if let ValueKind::Reference(n) = func.kind {
+                    n
+                } else {
+                    unreachable!()
+                };
+                (
+                    SpannedValue {
+                        span: e.span(),
+                        kind: ValueKind::Call(name, Box::new(arg)),
+                    },
+                    Vec::new(),
+                )
+            },
+        );
+
         let annotation = just('@')
             .ignore_then(text::keyword("NoExport"))
             .map_with(|_, e| {
@@ -380,6 +399,7 @@ fn spanned_value_no_pad<'a>()
             string,
             array,
             object,
+            call,
             chain,
             reference,
         ));

--- a/polsia/src/types.rs
+++ b/polsia/src/types.rs
@@ -14,6 +14,7 @@ pub enum Value {
     Object(Vec<(String, Value)>),
     Reference(String),
     Type(ValType),
+    Call(String, Box<Value>),
     Union(Vec<Value>),
 }
 
@@ -44,6 +45,7 @@ pub enum ValueKind {
     Object(Vec<(String, SpannedValue, Span, Vec<Annotation>)>),
     Reference(String),
     Type(ValType),
+    Call(String, Box<SpannedValue>),
     Union(Vec<SpannedValue>),
 }
 
@@ -64,6 +66,7 @@ impl SpannedValue {
             ),
             ValueKind::Reference(r) => Value::Reference(r.clone()),
             ValueKind::Type(t) => Value::Type(t.clone()),
+            ValueKind::Call(name, arg) => Value::Call(name.clone(), Box::new(arg.to_value())),
             ValueKind::Union(items) => Value::Union(items.iter().map(|v| v.to_value()).collect()),
         }
     }
@@ -85,6 +88,7 @@ impl Value {
             }
             Value::Reference(r) => JsValue::String(r.clone()),
             Value::Type(t) => panic!("unresolved type {:?}", t),
+            Value::Call(name, _) => panic!("unresolved call {}", name),
             Value::Union(_) => panic!("unresolved union"),
         }
     }


### PR DESCRIPTION
## Summary
- support function calls in the grammar and AST
- implement execution for a native `increment` function
- evaluate calls during unification and reference resolution
- add unit tests covering `increment`

## Testing
- `just polsia fmt`
- `just polsia clippy`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_684b86abb220832c9fa7828984aa0fd4