### PR TITLE
Add basic integer operators

### DIFF
--- a/polsia/src/types.rs
+++ b/polsia/src/types.rs
@@ -15,6 +15,7 @@ pub enum Value {
     Reference(String),
     Type(ValType),
     Call(String, Box<Value>),
+    OpCall(String, Box<Value>, Box<Value>),
     Union(Vec<Value>),
 }
 
@@ -46,6 +47,7 @@ pub enum ValueKind {
     Reference(String),
     Type(ValType),
     Call(String, Box<SpannedValue>),
+    OpCall(String, Box<SpannedValue>, Box<SpannedValue>),
     Union(Vec<SpannedValue>),
 }
 
@@ -67,6 +69,11 @@ impl SpannedValue {
             ValueKind::Reference(r) => Value::Reference(r.clone()),
             ValueKind::Type(t) => Value::Type(t.clone()),
             ValueKind::Call(name, arg) => Value::Call(name.clone(), Box::new(arg.to_value())),
+            ValueKind::OpCall(op, left, right) => Value::OpCall(
+                op.clone(),
+                Box::new(left.to_value()),
+                Box::new(right.to_value()),
+            ),
             ValueKind::Union(items) => Value::Union(items.iter().map(|v| v.to_value()).collect()),
         }
     }
@@ -89,6 +96,7 @@ impl Value {
             Value::Reference(r) => JsValue::String(r.clone()),
             Value::Type(t) => panic!("unresolved type {:?}", t),
             Value::Call(name, _) => panic!("unresolved call {}", name),
+            Value::OpCall(op, _, _) => panic!("unresolved op {}", op),
             Value::Union(_) => panic!("unresolved union"),
         }
     }


### PR DESCRIPTION
## Summary
- add `OpCall` variant for calling builtin operators
- parse + and - operations
- evaluate operators during unification
- treat unresolved operator calls like functions
- add new tests for operator usage

## Testing
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_684ba696776c832cb1336ffebf549be1